### PR TITLE
Use defaultProps to ensure postIds prop exists for ChannelPeek (#2159)

### DIFF
--- a/app/screens/channel_peek/channel_peek.js
+++ b/app/screens/channel_peek/channel_peek.js
@@ -23,6 +23,7 @@ export default class ChannelPeek extends PureComponent {
     };
 
     static defaultProps = {
+        postIds: [],
         postVisibility: 15,
     };
 


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).

When filling in a section please remove the help text and the above text.

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] All new/modified APIs include changes to [mattermost-redux](https://github.com/mattermost/mattermost-redux) (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates

#### Device Information
This PR was tested on: [Device name(s), OS version(s)] 

#### Screenshots
[If the PR includes UI changes, include screenshots (for both iOS and Android if possible).]
